### PR TITLE
[Fix] Fix the EnhanceDetVisualizationHook

### DIFF
--- a/lqit/detection/engine/hooks/visualization_hook.py
+++ b/lqit/detection/engine/hooks/visualization_hook.py
@@ -45,6 +45,11 @@ class EnhanceDetVisualizationHook(DetVisualizationHook):
         file_client_args (dict): Arguments to instantiate a FileClient.
             See :class:`mmengine.fileio.FileClient` for details.
             Defaults to ``dict(backend='disk')``.
+        show_on_enhance (bool): Whether show the detection results on the
+            enhanced image. Defaults to False
+        draw_gt (bool): Whether to draw GT DetDataSample. Default to False.
+        draw_pred (bool): Whether to draw Prediction DetDataSample.
+            Defaults to True.
     """
 
     def __init__(self,


### PR DESCRIPTION
The resize size in `mmcv.imresize` is (w, h). But ori_shape is (h, w)